### PR TITLE
Rewrite profile README for portfolio + interview readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,76 @@
-<h2 align='center'> Hello world, I'm Reem 👋 </h2>
-</div>
+<h1 align="center">Hi, I'm Reem 👋</h1>
 
+<p align="center">
+  Full-stack engineer based in Austria — building polished web apps end-to-end,
+  with a particular focus on modern React / Angular front-ends backed by
+  Node.js APIs.
+</p>
 
-### :woman_technologist: About Me:
-
-- :telescope: I am a <b>Front-End Engineer</b> based in Austria and contributing to frontend projects for building web and mobile applications from design up to deployement.
-
-- :seedling: Exploring SEO Technical Content Writing.
-
-- :mailbox:How to reach me: [![Gmail Badge](https://img.shields.io/badge/gmail-%23D14836.svg?&style=for-the-badge&logo=gmail&logoColor=white)](mailto:rimssboui@gmail.com?subject=Hello%20Reem)
----
-
-### :hammer_and_wrench: Languages and Tools:
-<div>
- <img src="https://github.com/devicons/devicon/blob/master/icons/javascript/javascript-original.svg" title="JavaScript" alt="JavaScript" width="40" height="40"/>&nbsp;
- <img src="https://github.com/devicons/devicon/blob/master/icons/react/react-original-wordmark.svg" title="React" alt="React" width="40" height="40"/>&nbsp;
- <img src="https://github.com/devicons/devicon/blob/master/icons/redux/redux-original.svg" title="Redux" alt="Redux " width="40" height="40"/>&nbsp;
- <img src="https://github.com/devicons/devicon/blob/master/icons/angularjs/angularjs-original.svg" title="Angular" alt="Angular " width="40" height="40"/>&nbsp;
- <img src="https://github.com/devicons/devicon/blob/master/icons/css3/css3-plain-wordmark.svg"  title="CSS3" alt="CSS" width="40" height="40"/>&nbsp;
- <img src="https://github.com/devicons/devicon/blob/master/icons/html5/html5-original.svg" title="HTML5" alt="HTML" width="40" height="40"/>&nbsp;
- <img src="https://github.com/devicons/devicon/blob/master/icons/materialui/materialui-original.svg" title="Material UI" alt="Material UI" width="40" height="40"/>&nbsp;
-<img src="https://github.com/devicons/devicon/blob/master/icons/bootstrap/bootstrap-original.svg" title="Bootstrap" alt="Bootstrap" width="40" height="40"/>&nbsp;
-   <img src="https://github.com/devicons/devicon/blob/master/icons/nodejs/nodejs-original-wordmark.svg" title="NodeJS" alt="NodeJS" width="40" height="40"/>&nbsp;
-  <img src="https://github.com/devicons/devicon/blob/master/icons/java/java-original-wordmark.svg" title="Java" alt="Java" width="40" height="40"/>&nbsp;
-   <img src="https://github.com/devicons/devicon/blob/master/icons/spring/spring-original-wordmark.svg" title="Spring" alt="Spring" width="40" height="40"/>&nbsp;
-  <img src="https://github.com/devicons/devicon/blob/master/icons/firebase/firebase-plain-wordmark.svg" title="Firebase" alt="Firebase" width="40" height="40"/>&nbsp;
-  <img src="https://github.com/devicons/devicon/blob/master/icons/mysql/mysql-original-wordmark.svg" title="MySQL"  alt="MySQL" width="40" height="40"/>&nbsp;
- <img src="https://github.com/devicons/devicon/blob/master/icons/mongodb/mongodb-plain-wordmark.svg" title="MongoDB"  alt="MongoDB" width="40" height="40"/>&nbsp;
-  <img src="https://github.com/devicons/devicon/blob/master/icons/git/git-original-wordmark.svg" title="Git" **alt="Git" width="40" height="40"/>
-</div>
+<p align="center">
+  <a href="mailto:rimssboui@gmail.com"><img src="https://img.shields.io/badge/Gmail-D14836?style=for-the-badge&logo=gmail&logoColor=white" alt="Email" /></a>
+  <a href="https://gitlab.com/rimssboui"><img src="https://img.shields.io/badge/GitLab-FC6D26?style=for-the-badge&logo=gitlab&logoColor=white" alt="GitLab" /></a>
+</p>
 
 ---
 
-### :fire: Github Stats:
+### 👩‍💻 About me
 
-[![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=reemsb&layout=compact&theme=vision-friendly-dark)](https://github.com/anuraghazra/github-readme-stats)
+- 🛠️ I ship features end-to-end — from API design and data modelling through to UI, animation, and CI.
+- 🧪 Strongest on the front-end (React 19 + TypeScript, Angular 19) but comfortable in the backend (Express, Mongoose, JWT, OAuth).
+- 🌱 Currently learning AWS and exploring AI agents.
+- ✉️ Easiest way to reach me: email above.
 
 ---
+
+### 🚀 Featured projects
+
+| Project | What it is | Stack |
+| --- | --- | --- |
+| **[foody-crud-mern](https://github.com/reemsb/foody-crud-mern)** | Per-user snack diary with JWT + Google sign-in, dark mono UI, Grid + Diary views, framer-motion animations | React 19 · Vite · Zustand · Express 5 · Mongoose · JWT · bcrypt · Google OAuth · Docker |
+| **[tv-recommend-app](https://github.com/reemsb/tv-recommend-app)** | TMDB browser with lazy-loaded routes, the new Angular control flow, and PrimeNG's Aura dark theme | Angular 19 (standalone) · TypeScript 5 · RxJS · PrimeNG · ESLint flat |
+| **[react-typescript-starter](https://github.com/reemsb/react-typescript-starter)** | Opinionated React + TS template — Vite, Router, Vitest, ESLint + Prettier, design tokens. Use as a fork base | Vite 6 · React 19 · React Router 7 · Vitest · ESLint 9 · Prettier 3 |
+
+---
+
+### 🧰 Tech I reach for
+
+**Front-end** — React · TypeScript · Angular · Vite · React Router · Zustand · framer-motion · SCSS / CSS Modules · Bootstrap · Material UI · PrimeNG
+
+**Back-end** — Node.js · Express · Mongoose · REST APIs · JWT · Google OAuth · bcrypt · Helmet · Java / Spring
+
+**Data** — MongoDB · MySQL · Firebase
+
+**Tooling** — ESLint 9 (flat config) · Prettier · Vitest · Karma + Jasmine · Docker · GitLab CI · Git
+
+<p>
+ <img src="https://github.com/devicons/devicon/blob/master/icons/react/react-original-wordmark.svg" title="React" alt="React" width="38" height="38"/>&nbsp;
+ <img src="https://github.com/devicons/devicon/blob/master/icons/typescript/typescript-original.svg" title="TypeScript" alt="TypeScript" width="38" height="38"/>&nbsp;
+ <img src="https://github.com/devicons/devicon/blob/master/icons/angularjs/angularjs-original.svg" title="Angular" alt="Angular" width="38" height="38"/>&nbsp;
+ <img src="https://github.com/devicons/devicon/blob/master/icons/javascript/javascript-original.svg" title="JavaScript" alt="JavaScript" width="38" height="38"/>&nbsp;
+ <img src="https://github.com/devicons/devicon/blob/master/icons/redux/redux-original.svg" title="Redux" alt="Redux" width="38" height="38"/>&nbsp;
+ <img src="https://github.com/devicons/devicon/blob/master/icons/nodejs/nodejs-original-wordmark.svg" title="Node.js" alt="Node.js" width="38" height="38"/>&nbsp;
+ <img src="https://github.com/devicons/devicon/blob/master/icons/express/express-original-wordmark.svg" title="Express" alt="Express" width="38" height="38"/>&nbsp;
+ <img src="https://github.com/devicons/devicon/blob/master/icons/mongodb/mongodb-plain-wordmark.svg" title="MongoDB" alt="MongoDB" width="38" height="38"/>&nbsp;
+ <img src="https://github.com/devicons/devicon/blob/master/icons/mysql/mysql-original-wordmark.svg" title="MySQL" alt="MySQL" width="38" height="38"/>&nbsp;
+ <img src="https://github.com/devicons/devicon/blob/master/icons/firebase/firebase-plain-wordmark.svg" title="Firebase" alt="Firebase" width="38" height="38"/>&nbsp;
+ <img src="https://github.com/devicons/devicon/blob/master/icons/java/java-original-wordmark.svg" title="Java" alt="Java" width="38" height="38"/>&nbsp;
+ <img src="https://github.com/devicons/devicon/blob/master/icons/spring/spring-original-wordmark.svg" title="Spring" alt="Spring" width="38" height="38"/>&nbsp;
+ <img src="https://github.com/devicons/devicon/blob/master/icons/html5/html5-original.svg" title="HTML5" alt="HTML5" width="38" height="38"/>&nbsp;
+ <img src="https://github.com/devicons/devicon/blob/master/icons/css3/css3-plain-wordmark.svg" title="CSS3" alt="CSS3" width="38" height="38"/>&nbsp;
+ <img src="https://github.com/devicons/devicon/blob/master/icons/sass/sass-original.svg" title="Sass" alt="Sass" width="38" height="38"/>&nbsp;
+ <img src="https://github.com/devicons/devicon/blob/master/icons/docker/docker-original-wordmark.svg" title="Docker" alt="Docker" width="38" height="38"/>&nbsp;
+ <img src="https://github.com/devicons/devicon/blob/master/icons/git/git-original-wordmark.svg" title="Git" alt="Git" width="38" height="38"/>
+</p>
+
+---
+
+### 📊 GitHub stats
+
+<p>
+  <img height="160" src="https://github-readme-stats.vercel.app/api?username=reemsb&show_icons=true&hide_border=true&theme=vision-friendly-dark&include_all_commits=true" alt="GitHub stats" />
+  <img height="160" src="https://github-readme-stats.vercel.app/api/top-langs/?username=reemsb&layout=compact&hide_border=true&theme=vision-friendly-dark" alt="Top languages" />
+</p>
+
+---
+
+<sub>⚡ Lifelong learning — most of my portfolio code lives on <a href="https://gitlab.com/rimssboui">GitLab</a> and mirrors here.</sub>


### PR DESCRIPTION
## Why

The current profile README is the GitHub default "logo wall" template. For someone using this profile as a portfolio entry point (interviews, job search), it's underselling — it lists tools but doesn't show what's been built with them, and the bio says "Front-End Engineer" while the actual projects include real backend work (Express + Mongoose + JWT + Google OAuth in foody-crud-mern).

## What changed

- **Positioning**: "Full-stack engineer based in Austria — front-end strength, full-stack depth." Reflects what the repos actually demonstrate.
- **Featured projects table** with `foody-crud-mern`, `tv-recommend-app`, and `react-typescript-starter` — links, one-line descriptions, and per-project stack. The single most useful change for recruiters landing here.
- **Skills grouped by concern** (front-end / back-end / data / tooling) instead of one big icon wall. The icon wall is still there underneath, smaller, as visual sugar.
- **Two GitHub stats widgets** instead of one — general stats + top languages — both with the dark theme, no border.
- **Cleaner contact strip**: Gmail + GitLab badges with consistent styling.
- **"Currently exploring" → "Currently learning AWS and exploring AI agents."** Honest about start-of-learning on AWS, signals contemporary curiosity.

## Preview

Open the file diff to see the markdown. To preview the *rendered* result, you can either:
- Merge to `main` (it'll appear on github.com/reemsb)
- Or use a temporary GitHub Gist with the raw markdown